### PR TITLE
Corrected description for underscores (2.1)

### DIFF
--- a/data/patches/gh-ce09-underscores.json
+++ b/data/patches/gh-ce09-underscores.json
@@ -1,0 +1,44 @@
+{
+	"id": "twt8ut",
+	"name": "underscores",
+	"description": "underscores, real name April Harper Grey, is an American EDM/hyperpop music producer, born in California and based in New York. She is also a member of the group Six Impala.",
+	"links": {
+		"website": [
+			"https://underscores.plus",
+			"https://twitter.com/underscoresplus",
+			"https://open.spotify.com/artist/7HfUJxeVTgrvhk0eWHFzV7"
+		],
+		"subreddit": [
+			"underscores"
+		],
+		"discord": [
+			"UeWkrt7XTD"
+		]
+	},
+	"path": {
+		"T:0-1, 21-164": [
+			[
+				463,
+				729
+			],
+			[
+				497,
+				729
+			],
+			[
+				497,
+				738
+			],
+			[
+				463,
+				738
+			]
+		]
+	},
+	"center": {
+		"T:0-1, 21-164": [
+			480,
+			734
+		]
+	}
+}


### PR DESCRIPTION
Recreation of #1467. Somehow the patch is not implemented.

I accidentally closed #1485, thinking it was merged.